### PR TITLE
Merge setup_vars_*.sh into env.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ In order to build/run Go code that uses this package, you will need to specify t
 
 One time per session, you must run the script:
 
-		source ./setupvars_linux.sh
+		source ./env.sh
 
 Now you should be able to build or run any of the examples:
 
@@ -164,7 +164,7 @@ In order to build/run Go code that uses this package, you will need to specify t
 
 One time per session, you must run the script:
 
-		source ./setupvars_osx.sh
+		source ./env.sh
 
 Now you should be able to build or run any of the examples:
 

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,14 @@
+uname_val="$(uname)"
+if [[ "$uname_val" == "Darwin" ]]; then
+  export CGO_CPPFLAGS="-I/usr/local/Cellar/opencv/3.3.0/include -I/usr/local/Cellar/opencv/3.3.0/include/opencv2"
+  export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
+  export CGO_LDFLAGS="-L/usr/local/Cellar/opencv/3.3.0/lib -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_calib3d"
+  echo "Environment variables configured for OSX"
+elif [[ "$uname_val" == "Linux" ]]; then
+  export CGO_CPPFLAGS="-I/usr/local/include"
+  export CGO_CXXFLAGS="--std=c++1z"
+  export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_calib3d"
+  echo "Environment variables configured for Linux"
+else
+  echo "Unknown platform '$uname_val'!"
+fi

--- a/setupvars_linux.sh
+++ b/setupvars_linux.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export CGO_CPPFLAGS="-I/usr/local/include"
-export CGO_CXXFLAGS="--std=c++1z"
-export CGO_LDFLAGS="-L/usr/local/lib -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_calib3d"

--- a/setupvars_osx.sh
+++ b/setupvars_osx.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export CGO_CPPFLAGS="-I/usr/local/Cellar/opencv/3.3.0/include -I/usr/local/Cellar/opencv/3.3.0/include/opencv2"
-export CGO_CXXFLAGS="--std=c++1z -stdlib=libc++"
-export CGO_LDFLAGS="-L/usr/local/Cellar/opencv/3.3.0/lib -lopencv_core -lopencv_videoio -lopencv_imgproc -lopencv_highgui -lopencv_imgcodecs -lopencv_objdetect -lopencv_calib3d"


### PR DESCRIPTION
This reduces the different flows users have to follow based on their OS.

Remove the +x bit on the script, since it is not meant to be executed but
sourced. Remove the shebang for the same reason.